### PR TITLE
Add teamVSorg flag for users, fix repos directory creation bug

### DIFF
--- a/src/main/java/org/example/data/Repository.java
+++ b/src/main/java/org/example/data/Repository.java
@@ -24,6 +24,7 @@ public class Repository extends GitHubObject implements Serializable {
     public List<PullRequest> pullRequests;
     public List<Issue> issues;
 
+    public User owner;
     public List<User> contributors;
 
     public Repository() {}
@@ -39,6 +40,7 @@ public class Repository extends GitHubObject implements Serializable {
         pullRequests = extractPullRequests(repo);
         issues = extractIssues(repo);
 
+        owner = new User(repo.getOwner());
         contributors = extractContributors(repo);
     }
 

--- a/src/main/java/org/example/data/User.java
+++ b/src/main/java/org/example/data/User.java
@@ -10,10 +10,12 @@ public class User implements Serializable {
 
     public String name;
     public Instant accountCreatedAt;
+    public String type;
 
     public User() {}
 
     public User(GHUser user) throws IOException {
         accountCreatedAt = user.getCreatedAt();
+        type = user.getType();
     }
 }

--- a/src/main/java/org/example/fetching/CachedDataRepoFetcher.java
+++ b/src/main/java/org/example/fetching/CachedDataRepoFetcher.java
@@ -37,14 +37,16 @@ public class CachedDataRepoFetcher {
         Repository repo = new Repository(gh.getRepository(repoName));
 
         logger.info("Done reading from API, writing to file.");
-        if (output.getParentFile().mkdirs()) {
-            mapper.writerWithDefaultPrettyPrinter()
-                    .writeValue(output, repo);
-            return repo;
-        } else {
+
+        if(!output.getParentFile().exists() && !output.getParentFile().mkdirs()) {
             logger.error("Failed to create directories, necessary to save repo data.");
             throw new RemoteException("Error `.mkdirs()`. Directories not created.");
         }
+
+        mapper.writerWithDefaultPrettyPrinter()
+                .writeValue(output, repo);
+
+        return repo;
     }
 
     public static Repository getRepoData(GitHub gh, String repoName) throws IOException {


### PR DESCRIPTION
- Added a `type` field for users so that we can check whether the repo is user- or organization-owned (I need it)
- Fixed a bug in the creation of the repos directory
  - Previously, we only called the `mkdirs()` method and threw an exception if this method returned false
  - This method returns false if either the repo already exists, or sth else fails — hence, we have an exception when we try to save a second repo (since the `repos/` directory already exists and the method will return false)
  - Now, we only throw an exception when the directory is not created yet AND the creation fails for some other reason; otherwise, we save the file about repo data