### PR TITLE
Add classes and fields for calculating the "delivery efficiency" KPIs, refactor extraction from repo

### DIFF
--- a/src/main/java/org/example/data/Commit.java
+++ b/src/main/java/org/example/data/Commit.java
@@ -1,0 +1,17 @@
+package org.example.data;
+
+import org.kohsuke.github.GHCommit;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+public class Commit implements Serializable {
+
+    public String sha1;
+
+    public Commit() {}
+
+    public Commit(GHCommit commit) throws IOException {
+        sha1 = commit.getSHA1();
+    }
+}

--- a/src/main/java/org/example/data/PullRequest.java
+++ b/src/main/java/org/example/data/PullRequest.java
@@ -1,7 +1,6 @@
 package org.example.data;
 
 import org.kohsuke.github.GHPullRequest;
-import org.kohsuke.github.GHRepository;
 
 import java.io.IOException;
 import java.io.Serializable;

--- a/src/main/java/org/example/data/Release.java
+++ b/src/main/java/org/example/data/Release.java
@@ -1,0 +1,22 @@
+package org.example.data;
+
+import org.kohsuke.github.GHRelease;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.time.Instant;
+
+public class Release extends GitHubObject implements Serializable {
+
+    Instant publishedAt;
+    String tagName;
+
+    public Release() {}
+
+    public Release(GHRelease release) throws IOException {
+        super(release);
+
+        publishedAt = release.getPublishedAt();
+        tagName = release.getTagName();
+    }
+}

--- a/src/main/java/org/example/data/Release.java
+++ b/src/main/java/org/example/data/Release.java
@@ -8,8 +8,8 @@ import java.time.Instant;
 
 public class Release extends GitHubObject implements Serializable {
 
-    Instant publishedAt;
-    String tagName;
+    public Instant publishedAt;
+    public String tagName;
 
     public Release() {}
 

--- a/src/main/java/org/example/data/Repository.java
+++ b/src/main/java/org/example/data/Repository.java
@@ -1,12 +1,12 @@
 package org.example.data;
 
+import org.example.extraction.DataExtractor;
 import org.kohsuke.github.*;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 
 public class Repository extends GitHubObject implements Serializable {
@@ -40,58 +40,13 @@ public class Repository extends GitHubObject implements Serializable {
         defaultBranch = repo.getDefaultBranch();
         branches = repo.getBranches().keySet().stream().toList();
 
-        pullRequests = extractPullRequests(repo);
-        issues = extractIssues(repo);
+        pullRequests = DataExtractor.extractPullRequests(repo);
+        issues = DataExtractor.extractIssues(repo, dateCutoff);
 
         owner = new User(repo.getOwner());
-        contributors = extractContributors(repo);
+        contributors = DataExtractor.extractContributors(repo);
 
-        releases = extractReleases(repo);
-        tags = extractTags(repo);
-    }
-
-    private List<PullRequest> extractPullRequests(GHRepository repo) throws IOException {
-        List<PullRequest> prs = new ArrayList<>();
-        for (GHPullRequest p : repo.queryPullRequests().state(GHIssueState.ALL).list()) {
-            prs.add(new PullRequest(p));
-        }
-
-        return prs;
-    }
-
-    private List<Issue> extractIssues(GHRepository repo) throws IOException {
-        List<Issue> issues = new ArrayList<>();
-        for  (GHIssue i : repo.queryIssues().since(dateCutoff).list()) {
-            issues.add(new Issue(i));
-        }
-
-        return issues;
-    }
-
-    private List<User> extractContributors(GHRepository repo) throws IOException {
-        List<User> users = new ArrayList<>();
-        for  (GHUser u : repo.listContributors()) {
-            users.add(new User(u));
-        }
-
-        return users;
-    }
-
-    private List<Release> extractReleases(GHRepository repo) throws IOException {
-        List<Release> releases = new ArrayList<>();
-        for  (GHRelease r : repo.listReleases()) {
-            releases.add(new Release(r));
-        }
-
-        return releases;
-    }
-
-    private List<Tag> extractTags(GHRepository repo) throws IOException {
-        List<Tag> tags = new ArrayList<>();
-        for  (GHTag t : repo.listTags()) {
-            tags.add(new Tag(t));
-        }
-
-        return tags;
+        releases = DataExtractor.extractReleases(repo);
+        tags = DataExtractor.extractTags(repo);
     }
 }

--- a/src/main/java/org/example/data/Repository.java
+++ b/src/main/java/org/example/data/Repository.java
@@ -27,6 +27,9 @@ public class Repository extends GitHubObject implements Serializable {
     public User owner;
     public List<User> contributors;
 
+    public List<Release> releases;
+    public List<Tag> tags;
+
     public Repository() {}
 
     public Repository(GHRepository repo) throws IOException {
@@ -42,6 +45,9 @@ public class Repository extends GitHubObject implements Serializable {
 
         owner = new User(repo.getOwner());
         contributors = extractContributors(repo);
+
+        releases = extractReleases(repo);
+        tags = extractTags(repo);
     }
 
     private List<PullRequest> extractPullRequests(GHRepository repo) throws IOException {
@@ -69,5 +75,23 @@ public class Repository extends GitHubObject implements Serializable {
         }
 
         return users;
+    }
+
+    private List<Release> extractReleases(GHRepository repo) throws IOException {
+        List<Release> releases = new ArrayList<>();
+        for  (GHRelease r : repo.listReleases()) {
+            releases.add(new Release(r));
+        }
+
+        return releases;
+    }
+
+    private List<Tag> extractTags(GHRepository repo) throws IOException {
+        List<Tag> tags = new ArrayList<>();
+        for  (GHTag t : repo.listTags()) {
+            tags.add(new Tag(t));
+        }
+
+        return tags;
     }
 }

--- a/src/main/java/org/example/data/Repository.java
+++ b/src/main/java/org/example/data/Repository.java
@@ -24,6 +24,7 @@ public class Repository extends GitHubObject implements Serializable {
     public List<PullRequest> pullRequests;
     public List<Issue> issues;
 
+    public User owner;
     public List<User> contributors;
 
     public Repository() {}
@@ -39,6 +40,7 @@ public class Repository extends GitHubObject implements Serializable {
         pullRequests = extractPullRequests(repo);
         issues = extractIssues(repo);
 
+        owner = new User(repo.getOwner());
         contributors = extractContributors(repo);
     }
 

--- a/src/main/java/org/example/data/Tag.java
+++ b/src/main/java/org/example/data/Tag.java
@@ -1,0 +1,19 @@
+package org.example.data;
+
+import org.kohsuke.github.GHTag;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+public class Tag implements Serializable {
+
+    public Commit commit;
+    public String name;
+
+    public Tag() {}
+
+    public Tag(GHTag tag) throws IOException {
+        commit = new Commit(tag.getCommit());
+        name = tag.getName();
+    }
+}

--- a/src/main/java/org/example/data/User.java
+++ b/src/main/java/org/example/data/User.java
@@ -10,10 +10,12 @@ public class User implements Serializable {
 
     public String name;
     public Instant accountCreatedAt;
+    public String type;
 
     public User() {}
 
     public User(GHUser user) throws IOException {
         accountCreatedAt = user.getCreatedAt();
+        type = user.getType();
     }
 }

--- a/src/main/java/org/example/extraction/DataExtractor.java
+++ b/src/main/java/org/example/extraction/DataExtractor.java
@@ -1,4 +1,56 @@
 package org.example.extraction;
 
+import org.example.data.*;
+import org.kohsuke.github.*;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
 public class DataExtractor {
+    public static List<PullRequest> extractPullRequests(GHRepository repo) throws IOException {
+        List<PullRequest> prs = new ArrayList<>();
+        for (GHPullRequest p : repo.queryPullRequests().state(GHIssueState.ALL).list()) {
+            prs.add(new PullRequest(p));
+        }
+
+        return prs;
+    }
+
+    public static List<Issue> extractIssues(GHRepository repo, Instant dateCutoff) throws IOException {
+        List<Issue> issues = new ArrayList<>();
+        for  (GHIssue i : repo.queryIssues().since(dateCutoff).list()) {
+            issues.add(new Issue(i));
+        }
+
+        return issues;
+    }
+
+    public static List<User> extractContributors(GHRepository repo) throws IOException {
+        List<User> users = new ArrayList<>();
+        for  (GHUser u : repo.listContributors()) {
+            users.add(new User(u));
+        }
+
+        return users;
+    }
+
+    public static List<Release> extractReleases(GHRepository repo) throws IOException {
+        List<Release> releases = new ArrayList<>();
+        for  (GHRelease r : repo.listReleases()) {
+            releases.add(new Release(r));
+        }
+
+        return releases;
+    }
+
+    public static List<Tag> extractTags(GHRepository repo) throws IOException {
+        List<Tag> tags = new ArrayList<>();
+        for  (GHTag t : repo.listTags()) {
+            tags.add(new Tag(t));
+        }
+
+        return tags;
+    }
 }

--- a/src/main/java/org/example/fetching/CachedDataRepoFetcher.java
+++ b/src/main/java/org/example/fetching/CachedDataRepoFetcher.java
@@ -37,14 +37,16 @@ public class CachedDataRepoFetcher {
         Repository repo = new Repository(gh.getRepository(repoName));
 
         logger.info("Done reading from API, writing to file.");
-        if (output.getParentFile().mkdirs()) {
-            mapper.writerWithDefaultPrettyPrinter()
-                    .writeValue(output, repo);
-            return repo;
-        } else {
+
+        if(!output.getParentFile().exists() && !output.getParentFile().mkdirs()) {
             logger.error("Failed to create directories, necessary to save repo data.");
             throw new RemoteException("Error `.mkdirs()`. Directories not created.");
         }
+
+        mapper.writerWithDefaultPrettyPrinter()
+                .writeValue(output, repo);
+
+        return repo;
     }
 
     public static Repository getRepoData(GitHub gh, String repoName) throws IOException {


### PR DESCRIPTION
- Added the classes and fields necessary for calculating the "delivery efficiency" KPIs
  - Extract both tags and releases
    - We agreed with Sebastian that releases will be used as a proxy for deliveries; however, there is no way to calculate changes between two releases (and thus, get the "delivery size" metric)
    - So, we also extract tags which can be then matched to releases, and we can compare the commits pointed by the tags to get the diff and estimate the delivery size
  - "Delivery frequency" would be straightforward only using the list of releases
  - "Changes lead time" would use the date of the release and the date of the commits before the tag assoc. with the release (hence, we also need tags and commits for this metric) to calculate the time elapsed between the commit push and the release triggered
 
 - As suggested by @Zakrok09 in #2, I have refactored the extraction methods
   - The `extract()` method for each `GHObject` should be static so there is no benefit of having an `Extractable` interface with only one method, which is not enforced (being static)
   - To that end, moved the private extraction methods to the `DataExtractor` class (which was empty and I am not sure what it was meant for) and made them public static; now, we can extract issues from repo by `DataExtractor.extractIssues(repo);`
   
  _Follows #4_