### PR TITLE
Extract user login instead of name, remove collaborator flag

### DIFF
--- a/src/main/java/org/example/data/Commit.java
+++ b/src/main/java/org/example/data/Commit.java
@@ -17,7 +17,7 @@ public class Commit implements Serializable {
 
     public Commit(GHCommit commit) throws IOException {
         sha1 = commit.getSHA1();
-        author = new User(commit.getAuthor(), commit.getOwner());
+        author = new User(commit.getAuthor());
         commitDate = commit.getCommitDate();
         linesChanged = commit.getLinesChanged();
     }

--- a/src/main/java/org/example/data/User.java
+++ b/src/main/java/org/example/data/User.java
@@ -1,6 +1,5 @@
 package org.example.data;
 
-import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHUser;
 
 import java.io.IOException;
@@ -11,13 +10,11 @@ public class User implements Serializable {
 
     public String name;
     public Instant accountCreatedAt;
-    public boolean isCollaborator;
 
     public User() {}
 
-    public User(GHUser user, GHRepository repo) throws IOException {
-        name = user.getName();
+    public User(GHUser user) throws IOException {
+        name = user.getLogin();
         accountCreatedAt = user.getCreatedAt();
-        isCollaborator = repo.isCollaborator(user);
     }
 }


### PR DESCRIPTION
- After fetching some repos, I found the name of users (which we currently extract) is not unique per user and might sometimes be missing
  - This messes up the computation _per user_, where this would be used as a key to aggregate some other data
  - To that end, changed it to _login_, which is unique and always existing for users
- Additionally, removed the _isCollaborator_ flag
  - This information can be computed by looking at the commits so this turns out to be a unnecessary API call