### PR TITLE
Implement delivery efficiency KPIs computation

### DIFF
--- a/src/main/java/org/example/data/Release.java
+++ b/src/main/java/org/example/data/Release.java
@@ -18,20 +18,16 @@ public class Release extends GitHubObject implements Serializable {
 
     public Release() {}
 
-    public Release(GHRelease release, GHRelease prevRelease) throws IOException {
+    public Release(GHRelease release, String prevTag) throws IOException {
         super(release);
 
         publishedAt = release.getPublishedAt();
         tagName = release.getTagName();
-        changesFromPrevRelease = getNumChangesFromPrevRelease(prevRelease);
+        changesFromPrevRelease = getNumChangesFromPrevRelease(release.getOwner(), prevTag);
     }
 
-    private int getNumChangesFromPrevRelease(GHRelease prev) throws IOException {
-        if(prev == null) {
-            return 0;
-        }
-
-        GHCompare compare = prev.getOwner().getCompare(prev.getTagName(), tagName);
+    private int getNumChangesFromPrevRelease(GHRepository repo, String prevTag) throws IOException {
+        GHCompare compare = repo.getCompare(prevTag, tagName);
 
         return Arrays.stream(compare.getFiles())
                 .mapToInt(GHCommit.File::getLinesChanged)

--- a/src/main/java/org/example/data/Repository.java
+++ b/src/main/java/org/example/data/Repository.java
@@ -44,7 +44,7 @@ public class Repository extends GitHubObject implements Serializable {
         pullRequests = DataExtractor.extractPullRequests(repo);
         issues = DataExtractor.extractIssues(repo);
 
-        releases = DataExtractor.extractReleases(repo);
+        releases = DataExtractor.extractReleases(repo, commits.get(commits.size() - 1));
 
         // TODO: Should we extract check runs for all repositories the same way we do for PRs, issues, ....
         // OR Do we create a method getCheckRuns() which will use APICatcher and we call it for each repository when calculating CFR?

--- a/src/main/java/org/example/extraction/DataExtractor.java
+++ b/src/main/java/org/example/extraction/DataExtractor.java
@@ -28,16 +28,16 @@ public class DataExtractor {
         return issues;
     }
 
-    public static List<Release> extractReleases(GHRepository repo) throws IOException {
+    public static List<Release> extractReleases(GHRepository repo, Commit initCommit) throws IOException {
         List<Release> releases = new ArrayList<>();
         List<GHRelease> ghReleases = repo.listReleases().toList();
 
         for  (int i = 0; i < ghReleases.size() - 1; i++) {
-            releases.add(new Release(ghReleases.get(i), ghReleases.get(i + 1)));
+            releases.add(new Release(ghReleases.get(i), ghReleases.get(i + 1).getTagName()));
         }
 
         if(!ghReleases.isEmpty()) {
-            releases.add(new Release(ghReleases.get(ghReleases.size() - 1), null));
+            releases.add(new Release(ghReleases.get(ghReleases.size() - 1), initCommit.sha1));
         }
 
         return releases;


### PR DESCRIPTION
Added the implementation of the delivery efficiency KPIs:
- Delivery Frequency
  - The total number of releases within each considered interval

- Delivery Size
  - The total number of changed LOCs between successive releases in each interval
  - For each release, the changed LOCs from the previous release is stored in the `changesFromPrevRelease` field, which is then used to count changes per interval
  - For the first release, the changes from the first (initial) commit are computed
    - I have assumed the first commit contains the skeleton (boilerplate) code so it is not suitable to have the changed LOCs for the first release to be the entire release itself
    
- Change Lead Time (CLT)
  - For each release, the average duration for a commit to appear in that release is computed
    - Only the commits that are included for the first time in this release are considered 
  - Then, these avg CLTs per release are again averaged to obtain avg CLTs per interval